### PR TITLE
Pass models as strings

### DIFF
--- a/llmchain/src/llms/openai/openai.rs
+++ b/llmchain/src/llms/openai/openai.rs
@@ -63,8 +63,8 @@ pub struct OpenAI {
     // We generally recommend altering this or top_p but not both.
     temperature: RwLock<f32>,
 
-    embedding_model: RwLock<OpenAIEmbeddingModel>,
-    generate_model: RwLock<OpenAIGenerateModel>,
+    embedding_model: RwLock<String>,
+    generate_model: RwLock<String>,
 }
 
 impl OpenAI {
@@ -74,8 +74,8 @@ impl OpenAI {
             api_key: api_key.to_string(),
             max_tokens: RwLock::new(4095),
             temperature: RwLock::new(1.0),
-            embedding_model: RwLock::new(OpenAIEmbeddingModel::TextEmbeddingAda002),
-            generate_model: RwLock::new(OpenAIGenerateModel::Gpt35),
+            embedding_model: RwLock::new(OpenAIEmbeddingModel::TextEmbeddingAda002.to_string()),
+            generate_model: RwLock::new(OpenAIGenerateModel::Gpt35.to_string()),
         })
     }
 
@@ -89,13 +89,13 @@ impl OpenAI {
         self.clone()
     }
 
-    pub fn with_embedding_model(self: &Arc<Self>, model: OpenAIEmbeddingModel) -> Arc<Self> {
-        *self.embedding_model.write() = model;
+    pub fn with_embedding_model<M: Into<String>>(self: &Arc<Self>, model: M) -> Arc<Self> {
+        *self.embedding_model.write() = model.into();
         self.clone()
     }
 
-    pub fn with_generate_model(self: &Arc<Self>, model: OpenAIGenerateModel) -> Arc<Self> {
-        *self.generate_model.write() = model;
+    pub fn with_generate_model<M: Into<String>>(self: &Arc<Self>, model: M) -> Arc<Self> {
+        *self.generate_model.write() = model.into();
         self.clone()
     }
 

--- a/llmchain/tests/it/llms/openai/openai.rs
+++ b/llmchain/tests/it/llms/openai/openai.rs
@@ -38,7 +38,7 @@ async fn test_llm_openai_generate_gpt35() -> Result<()> {
 async fn test_llm_openai_generate_gpt4() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").unwrap_or("".to_string());
 
-    let llm = OpenAI::create(&api_key).with_generate_model(OpenAIGenerateModel::Gpt4);
+    let llm = OpenAI::create(&api_key).with_generate_model(OpenAIGenerateModel::Gpt4.to_string());
     let result = llm.generate("say Hello").await?;
     let generation = result.generation;
     assert!(generation.contains("Hello"));


### PR DESCRIPTION
fixes https://github.com/shafishlabs/llmchain-rs/issues/76.

My hope is to use this for ollama.

Currently the following code make the correct request but since the response types are not correct it fails. Once OpenAI compatibility later is added via https://github.com/ollama/ollama/issues/2416, this should work.


```rust
use llmchain::{Embedding, OpenAI, OpenAIEmbedding};

#[tokio::main]
async fn main() -> anyhow::Result<()> {
    let embedding = OpenAIEmbedding::create(
        OpenAI::create("ollama")
            .with_api_base("http://localhost:11434/")
            .with_embedding_model("nomic-embed-text"),
    );
    let result = embedding.embed_query("What is the name").await?;
    dbg!(&result);
    Ok(())
}
```

This is how to request embedding in ollama now.
```
 curl http://localhost:11434/api/embeddings -d '{
  "model": "nomic-embed-text",
  "prompt": "The sky is blue because of Rayleigh scattering"
}'
```

I expect the url to change to `http://localhost:11434/v1/embeddings` when OpenAI compatibility is added. Base url can be changed via https://github.com/shafishlabs/llmchain-rs/pull/77